### PR TITLE
Error in Progress bar (types)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 dist/
 MANIFEST
 *.egg-info
+*#*#*
+.#*

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Ubuntu:
 *******
 ::
 
-    # Add SoapySDR PPA to your system
+    # Add SoapySDR PPA to your system (pre 22.04, now in repositories)
     sudo add-apt-repository -y ppa:myriadrf/drivers
 
     # Update list of packages

--- a/qspectrumanalyzer/__main__.py
+++ b/qspectrumanalyzer/__main__.py
@@ -263,9 +263,10 @@ class QSpectrumAnalyzerMainWindow(QtWidgets.QMainWindow, Ui_QSpectrumAnalyzerMai
 
     def update_progress(self, value):
         """Update progress bar"""
-        value *= 1000
+        # progress bar needs all values in int
+        value = int(value * 1000) #resolution is thousandths
         value_max = int(self.intervalSpinBox.value() * 1000)
-
+        
         if value_max < 1000:
             return
 

--- a/qspectrumanalyzer/__main__.py
+++ b/qspectrumanalyzer/__main__.py
@@ -264,7 +264,7 @@ class QSpectrumAnalyzerMainWindow(QtWidgets.QMainWindow, Ui_QSpectrumAnalyzerMai
     def update_progress(self, value):
         """Update progress bar"""
         value *= 1000
-        value_max = self.intervalSpinBox.value() * 1000
+        value_max = int(self.intervalSpinBox.value() * 1000)
 
         if value_max < 1000:
             return
@@ -300,7 +300,7 @@ class QSpectrumAnalyzerMainWindow(QtWidgets.QMainWindow, Ui_QSpectrumAnalyzerMai
         self.start_timestamp = self.prev_data_timestamp
 
         if self.intervalSpinBox.value() >= 1:
-            self.progressbar.setRange(0, self.intervalSpinBox.value() * 1000)
+            self.progressbar.setRange(0, int(self.intervalSpinBox.value() * 1000))
         else:
             self.progressbar.setRange(0, 0)
         self.update_progress(0)


### PR DESCRIPTION
broke out a new dev env and then saw..
@foleyj2 [already fixed this like a bo$$ !](https://github.com/xmikos/qspectrumanalyzer/pull/112)

> Kubuntu 22.04, Python 3.11.6
> Gives error
> File "XXXX/qspectrumanalyzer/main.py", line 280, in update_progress
> self.progressbar.setValue(value)
> TypeError: setValue(self, value: int): argument 1 has unexpected type 'float'
> 
> Suggested documentation change and fixing types in progress bar method.

I second this, Ubuntu Jammy 22.04.5 LTS:

```
$ qspectrumanalyzer
Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
QSocketNotifier: Can only be used with threads started with QThread
libEGL warning: MESA-LOADER: failed to open iris: /usr/lib/dri/iris_dri.so: cannot open shared object file: No such file or directory (search paths /usr/lib/x86_64-linux-gnu/dri:\$${ORIGIN}/dri:/usr/lib/dri, suffix _dri)

libEGL warning: MESA-LOADER: failed to open swrast: /usr/lib/dri/swrast_dri.so: cannot open shared object file: No such file or directory (search paths /usr/lib/x86_64-linux-gnu/dri:\$${ORIGIN}/dri:/usr/lib/dri, suffix _dri)

qt.qpa.wayland: Failed to initialize EGL display 3001
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.13/site-packages/qspectrumanalyzer/__main__.py", line 372, in on_singleShotButton_clicked
    self.start(single_shot=True)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/lib/python3.13/site-packages/qspectrumanalyzer/__main__.py", line 303, in start
    self.progressbar.setRange(0, self.intervalSpinBox.value() * 1000)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: setRange(self, minimum: int, maximum: int): argument 2 has unexpected type 'float'
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.13/site-packages/qspectrumanalyzer/__main__.py", line 368, in on_startButton_clicked
    self.start()
    ~~~~~~~~~~^^
  File "/home/user/.local/lib/python3.13/site-packages/qspectrumanalyzer/__main__.py", line 303, in start
    self.progressbar.setRange(0, self.intervalSpinBox.value() * 1000)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: setRange(self, minimum: int, maximum: int): argument 2 has unexpected type 'float'

```
Looks like this is true for both PySide2 and PyQt5.. not sure how it ever ran? :confused: 

Awesome tool we gotta get working.

At least it's written in python, so years of signal sw dev retirement (`Core.XP.software--;`) can hopefully be un-done pretty quickly and will share "cross XP" gains with other more data-based, allegedly profitable project efforts.